### PR TITLE
Fix/Issue 29

### DIFF
--- a/lsnms/nms.py
+++ b/lsnms/nms.py
@@ -59,7 +59,7 @@ def _nms(
 
         # Query the overlapping boxes and return their intersection
         # return only boxes which have at least one pixel of overlap with the box of interest
-        query, query_intersections = rtree.intersect(boxA, 1.0)
+        query, query_intersections = rtree.intersect(boxA, 0.0)
 
         for query_idx, overlap in zip(query, query_intersections):
             if not to_consider[query_idx]:
@@ -72,7 +72,7 @@ def _nms(
         to_consider[current_idx] = False
 
     keep = np.array(keep)
-    return np.argwhere(score_mask)[:,0][keep]
+    return np.argwhere(score_mask)[:, 0][keep]
 
 
 def nms(


### PR DESCRIPTION
This PR sets the minimal area required to return a box in the `RTree` intersection routine to `0.` The initial value of `1.` was based on the misconception that all bboxes' coordinates were expressed in pixels, hence no intersection could be smaller than 1 (pixel).

Users should be able to express their bbox in real world coordinates, or even normalize them, hence have area much smaller than 1., yet still having an IoU with the bbox in reference higher than the threshold.

Closes #29 